### PR TITLE
Use title case in announcements

### DIFF
--- a/src/main/java/be/woutzah/chatbrawl/races/types/blockrace/BlockRace.java
+++ b/src/main/java/be/woutzah/chatbrawl/races/types/blockrace/BlockRace.java
@@ -21,6 +21,7 @@ import be.woutzah.chatbrawl.util.Printer;
 import com.meowj.langutils.lang.LanguageHelper;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -160,7 +161,7 @@ public class BlockRace extends ContestantRace {
         return message
                 .replace("<block>", ChatBrawl.isLangUtilsIsEnabled() ?
                         LanguageHelper.getItemName(new ItemStack(blockEntry.getMaterial()), settingManager.getString(LanguageSetting.LANG))
-                        : blockEntry.getMaterial().toString().toLowerCase().replace("_", " "))
+                        : WordUtils.capitalizeFully(blockEntry.getMaterial().toString().replace("_", " ")))
                 .replace("<amount>", String.valueOf(blockEntry.getAmount()));
     }
 

--- a/src/main/java/be/woutzah/chatbrawl/races/types/craftrace/CraftRace.java
+++ b/src/main/java/be/woutzah/chatbrawl/races/types/craftrace/CraftRace.java
@@ -21,6 +21,7 @@ import be.woutzah.chatbrawl.util.Printer;
 import com.meowj.langutils.lang.LanguageHelper;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -172,7 +173,7 @@ public class CraftRace extends ContestantRace {
     public String replacePlaceholders(String message) {
         return message.replace("<item>", ChatBrawl.isLangUtilsIsEnabled() ?
                 LanguageHelper.getItemName(new ItemStack(craftEntry.getMaterial()), settingManager.getString(LanguageSetting.LANG))
-                :craftEntry.getMaterial().toString().toLowerCase().replace("_", " "))
+                : WordUtils.capitalizeFully(craftEntry.getMaterial().toString().replace("_", " ")))
                 .replace("<amount>", String.valueOf(craftEntry.getAmount()));
     }
 

--- a/src/main/java/be/woutzah/chatbrawl/races/types/fishrace/FishRace.java
+++ b/src/main/java/be/woutzah/chatbrawl/races/types/fishrace/FishRace.java
@@ -21,6 +21,7 @@ import be.woutzah.chatbrawl.util.Printer;
 import com.meowj.langutils.lang.LanguageHelper;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -161,7 +162,7 @@ public class FishRace extends ContestantRace {
     public String replacePlaceholders(String message) {
         return message.replace("<fish>", ChatBrawl.isLangUtilsIsEnabled() ?
                 LanguageHelper.getItemName(new ItemStack(fishEntry.getMaterial()), settingManager.getString(LanguageSetting.LANG))
-                : fishEntry.getMaterial().toString().toLowerCase().replace("_", " "))
+                : WordUtils.capitalizeFully(fishEntry.getMaterial().toString().replace("_", " ")))
                 .replace("<amount>", String.valueOf(fishEntry.getAmount()));
     }
 

--- a/src/main/java/be/woutzah/chatbrawl/races/types/foodrace/FoodRace.java
+++ b/src/main/java/be/woutzah/chatbrawl/races/types/foodrace/FoodRace.java
@@ -21,6 +21,7 @@ import be.woutzah.chatbrawl.util.Printer;
 import com.meowj.langutils.lang.LanguageHelper;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -155,7 +156,7 @@ public class FoodRace extends ContestantRace {
     public String replacePlaceholders(String message) {
         return message.replace("<food>", ChatBrawl.isLangUtilsIsEnabled() ?
                 LanguageHelper.getItemName(new ItemStack(foodEntry.getMaterial()), settingManager.getString(LanguageSetting.LANG))
-                : foodEntry.getMaterial().toString().toLowerCase().replace("_", " "))
+                : WordUtils.capitalizeFully(foodEntry.getMaterial().toString().replace("_", " ")))
                 .replace("<amount>", String.valueOf(foodEntry.getAmount()));
     }
 

--- a/src/main/java/be/woutzah/chatbrawl/races/types/huntrace/HuntRace.java
+++ b/src/main/java/be/woutzah/chatbrawl/races/types/huntrace/HuntRace.java
@@ -21,6 +21,7 @@ import be.woutzah.chatbrawl.util.Printer;
 import com.meowj.langutils.lang.LanguageHelper;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.World;
@@ -158,7 +159,7 @@ public class HuntRace extends ContestantRace {
 	public String replacePlaceholders(String message) {
 		return message.replace("<mob>", ChatBrawl.isLangUtilsIsEnabled() ?
 				LanguageHelper.getEntityName(huntEntry.getEntityType(), settingManager.getString(LanguageSetting.LANG))
-				: huntEntry.getEntityType().toString().toLowerCase().replace("_", " "))
+				: WordUtils.capitalizeFully(huntEntry.getEntityType().toString().replace("_", " ")))
 				.replace("<amount>", String.valueOf(huntEntry.getAmount()));
 	}
 


### PR DESCRIPTION
Currently, race announcements by ChatBrawl are in lowercase. This PR adjusts them to use title case.

Current:
![current](https://i.imgur.com/H8Lj20l.png)

With PR:
![withpr](https://i.imgur.com/ZaMYCuX.png)
